### PR TITLE
Update tap_klipper_instructions.md

### DIFF
--- a/config/tap_klipper_instructions.md
+++ b/config/tap_klipper_instructions.md
@@ -2,17 +2,28 @@
 
 There are a few changes you'll need to make in order to get Tap working properly.
 
-1. Update your Z endstop  
-   Under the `[stepper_z]` block, you'll want to comment out your `position_endstop` and change your `endstop_pin` so that it uses the virtual Z endstop for Tap.  
-   `endstop_pin: probe:z_virtual_endstop`
-1. Update your Z homing position  
-   If you use `[safe_z_home]`, change the location to the center of the bed. If you have a `[homing_override]` make sure that it moves the toolhead to the center of the bed before calling `G28 Z`.
-1. Update your probe's offsets  
-   Remember, with Tap, your nozzle IS the probe, so your `[probe] x_offset` and `[probe] y_offset` values should be 0 now. You'll need to manually calibrate the probe's Z offset by using `PROBE_CALIBRATE`.
-1. Add Tap's `activate_gcode:`  
-   This G-code will allow you to probe cold, but will also prevent you from probing with a nozzle at printing temperature (to try to preserve your build surface). This goes in the `[probe]` section of your config.  
+1. Update your Z endstop: 
+   
+   - Under the `[stepper_z]` block, you'll want to comment out your `position_endstop` and change your `endstop_pin` so that it uses the virtual Z endstop for Tap.
+   
+      - Example: `endstop_pin: probe:z_virtual_endstop`
+   
+   - Be sure to *also* remove any automatically saved `[stepper_z] position_endstop: ...` value that may be found at the **bottom** of your `printer.cfg`file.
 
-```
+2. Update your Z homing position: 
+   
+   - If you use `[safe_z_home]`, change the location to the center of the bed. If you have a `[homing_override]` make sure that it moves the toolhead to the center of the bed before calling `G28 Z`.
+   
+3. Update your probe's offsets: 
+   
+   - Remember, with Tap, your nozzle IS the probe, so your `[probe] x_offset` and `[probe] y_offset` values should be 0 now. You'll need to manually calibrate the probe's Z offset by using `PROBE_CALIBRATE`.
+   
+4. Add Tap's `activate_gcode:`  
+   
+   - This G-code will allow you to probe cold, but will also prevent you from probing with a nozzle at printing temperature (to try to preserve your build surface). This goes in the `[probe]` section of your config.  
+
+```jinja
+
 activate_gcode:
     {% set PROBE_TEMP = 150 %}
     {% set MAX_TEMP = PROBE_TEMP + 5 %}
@@ -29,4 +40,5 @@ activate_gcode:
             TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={ MAX_TEMP }
         {% endif %}
     {% endif %}
+    
 ```


### PR DESCRIPTION
- closes issue #27
- adds reminder to remove old autosaved `position_endstop` value for `stepper_z` if present
- improves readability