### PR TITLE
add quad_gantry_level points to instructions

### DIFF
--- a/config/tap_klipper_instructions.md
+++ b/config/tap_klipper_instructions.md
@@ -42,3 +42,30 @@ activate_gcode:
     {% endif %}
     
 ```
+
+5. Update yor `[quad_gantry_level]` points: (Voron 2.4 only)
+```jinja
+
+
+##  250mm build
+points:
+   50,50
+   50,200
+   200,200
+   200,50
+    
+##  for 300mm build
+points:
+   50,50
+   50,250
+   250,250
+   250,50
+
+## for 350mm build
+points:
+   50,50
+   50,300
+   300,300
+   300,50
+    
+```


### PR DESCRIPTION
It looks like [quad_gantry_level] for whatever reason doesn't use the probe offsets.
So you should change this with tab.

Probably the same is true for ztilt. But I don't own a Trident to test this. So maybe someone else can add a section for it.